### PR TITLE
Account for vmodtool event function API change

### DIFF
--- a/src/vmod_timers.c
+++ b/src/vmod_timers.c
@@ -11,7 +11,7 @@ typedef struct timersConfig
   int multiplier; // To go from seconds -> milli, micro or nanoseconds
 } config_t;
 
-int event_function(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
+int vmod_event_function(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
 {
   if (e != VCL_EVENT_LOAD)
     return (0);


### PR DESCRIPTION
Due to
https://github.com/varnishcache/varnish-cache/commit/d8ae26b5a0b4a1102360a61a145e4730e52d68bc,
the event function name now requires a prefix.